### PR TITLE
Respecting optional statusInfo field in certConf according to RFC4210 and Lightweight CMP

### DIFF
--- a/src/main/java/com/siemens/pki/lightweightcmpra/msgvalidation/MessageValidator.java
+++ b/src/main/java/com/siemens/pki/lightweightcmpra/msgvalidation/MessageValidator.java
@@ -350,9 +350,9 @@ public class MessageValidator implements ValidatorIF {
         final CertStatus certStatus = certStatusArray[0];
         // statusInfo OPTIONAL validate if set
         final PKIStatusInfo status = certStatus.getStatusInfo();
-        assertNotNull(status, PKIFailureInfo.addInfoNotAvailable,
-                "certStatus.StatusInfo required");
-        validateStatusInfo(status);
+        if (status != null) {
+            validateStatusInfo(status);
+        }
         assertNotNull(certStatus.getCertReqId(),
                 PKIFailureInfo.addInfoNotAvailable, "cert req id is null");
         assertEqual(certStatus.getCertReqId(), ASN1INTEGER_0,


### PR DESCRIPTION
It seems like the current LighweightCmpRa implementation is a little too strict about the `statusInfo` of a `certConf` message.

Currently, an accepted `certConf` message requires a `statusInfo`. However, according to [Lightweight CMP definition](https://datatracker.ietf.org/doc/html/draft-ietf-lamps-lightweight-cmp-profile-08#page-37) the `statusInfo` is recommended, but not required.

Of course, feedback regarding the change is highly appreciated.

Thanks in advance for having a look at this!