### PR TITLE
Make configuration doc more prominent and point out surprising behavior on MAC-based protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ mvn clean install -DskipTests=true -Dgpg.skip
 ```
 in both directories.
 
+## Configuration
+
+A [README file documents](/doc/config/README.md)
+the YAML-based configuration,
+explaining the file structure and the effect of key/value pairs.
+
 ## Running the RA
 
 Example YAML configuration files can be found at
@@ -207,11 +213,6 @@ is used for implementing some tests.
 
 A [README file](src/test/java/com/siemens/pki/lightweightcmpra/test/config/credentials/README.txt)
 describes structure, purpose and use of the test credentials.
-
-## Configuration
-
-A [README file](/doc/config/README.md)
-explains the YAML configuration file structure.
 
 ### CMP message transport variants
 

--- a/doc/config/README.md
+++ b/doc/config/README.md
@@ -413,6 +413,15 @@ It may contain the key/value pairs described below in any order:
 On the upstream interface,
 for certficate update (`KUR`) requests the reprotection mode is always **keep**.
 
+On the downstream interface, according to
+[RFC 9483 section 4.1.5](https://datatracker.ietf.org/doc/html/rfc9483#section-4.1.5),
+if a request message (e.g. of type `IR`) has MAC-based protection
+and the respective type of the outgoing response message (e.g., `IP`)
+is configured to be reprotected, any given configuration of outgoing
+credentials is ignored and the verification credentials are used instead.
+Yet on error validating the protection of the request message,
+the configured outgoing credentials are used for the error response message.
+
 
 #### The `VerificationContext` object
 

--- a/doc/config/README.md
+++ b/doc/config/README.md
@@ -61,7 +61,7 @@ or
 Uniform Resource Identifiers (URI), directory names, shared secrets, and passwords
 are case sensitive.**
 
-The format and syntax of an URI is specified in [RFC2396](https://www.ietf.org/rfc/rfc2396.txt).
+The format and syntax of an URI is specified in [RFC 2396](https://www.ietf.org/rfc/rfc2396).
 
 
 ## Matching array entries
@@ -80,10 +80,10 @@ equivalent strings `"ir"`, `"cr"`, `"kur"`, `"rr"`, and `"genm"` are allowed.
 An absent **bodyType** matches CMP messages of any type.
 
 While processing a CMP message (which may be a request or response, including
-an error message), its bodyType (see [RFC4210](https://datatracker.ietf.org/doc/html/rfc4210),
-section PKI Message Body) and any certProfile optionally given in the message header (see
-[CMP updates](https://datatracker.ietf.org/doc/html/draft-ietf-lamps-cmp-updates),
-section certProfile)
+an error message), its bodyType
+(see [RFC 9810 section 5.1.2](https://datatracker.ietf.org/doc/html/rfc9810#section-5.1.2))
+and any certProfile optionally given in the message header
+(see [RFC 9810 section 5.1.1.4](https://datatracker.ietf.org/doc/html/rfc9810#section-5.1.1.4))
 are matched against the array entries until a fully matching entry is found.
 This entry is then used to control the further processing of this message.
 
@@ -167,7 +167,7 @@ It must contain exactly one of the objects described below:
 The **`HttpServer` object** describes the instantiation
 of the downstream interface to an HTTP server.
 Its used for CMP request reception and response delivery
-as specified in [RFC 6712](https://www.rfc-editor.org/rfc/rfc6712.txt).
+as specified in [RFC 9811](https://www.rfc-editor.org/rfc/rfc9811).
 
 It must contain the key/value pair described below:
 
@@ -183,7 +183,7 @@ The hostname or IP part of the **UpstreamURI** will be ignored.
 The **`HttpsServer` object** describes the instantiation
 of the downstream interface to an HTTPS server.
 Its used for CMP request reception and response delivery
-as specified in [RFC 6712](https://www.rfc-editor.org/rfc/rfc6712.txt).
+as specified in [RFC 9811](https://www.rfc-editor.org/rfc/rfc9811).
 
 It must contain the key/value pairs described below in any order:
 
@@ -201,7 +201,7 @@ The serverTrust and serverCredentials describe the TLS server configuration.
 
 The **`CoapServer` object** describes the instantiation
 of the downstream interface to a CoAP endpoint as described in
-[RFC 7252](https://www.rfc-editor.org/rfc/rfc7252.txt).
+[RFC 7252](https://www.rfc-editor.org/rfc/rfc7252).
 The UDP server binds to the standard CoAP port 5683.
 
 It must contain the key/value pair described below:

--- a/doc/config/README.md
+++ b/doc/config/README.md
@@ -415,13 +415,10 @@ for certficate update (`KUR`) requests the reprotection mode is always **keep**.
 
 On the downstream interface, according to
 [RFC 9483 section 4.1.5](https://datatracker.ietf.org/doc/html/rfc9483#section-4.1.5),
-if a request message (e.g. of type `IR`) has MAC-based protection
-and the respective type of the outgoing response message (e.g., `IP`)
-is configured to be reprotected, any given configuration of outgoing
-credentials is ignored and the verification credentials are used instead.
+responses to MAC-based requests at Downstream are always reprotected using the 
+same credentials.
 Yet on error validating the protection of the request message,
 the configured outgoing credentials are used for the error response message.
-
 
 #### The `VerificationContext` object
 

--- a/doc/config/README.md
+++ b/doc/config/README.md
@@ -413,7 +413,11 @@ It may contain the key/value pairs described below in any order:
 On the upstream interface,
 for certficate update (`KUR`) requests the reprotection mode is always **keep**.
 
-When responding to request messages that include successfully verified MAC-based protection, the corresponding response messages are protected using the same MAC-based algorithm, credentials, and parameters — regardless of the configuration related to reprotection or output credentials.
+When responding to request messages with successfully verified MAC-based protection,
+the corresponding response messages are protected
+using the same MAC-based algorithm, credentials, and parameters
+(regardless of the configuration related to reprotection or output credentials).
+
 
 Yet on error validating the protection of the request message,
 the configured outgoing credentials are used for the error response message.

--- a/doc/config/README.md
+++ b/doc/config/README.md
@@ -413,10 +413,8 @@ It may contain the key/value pairs described below in any order:
 On the upstream interface,
 for certficate update (`KUR`) requests the reprotection mode is always **keep**.
 
-On the downstream interface, according to
-[RFC 9483 section 4.1.5](https://datatracker.ietf.org/doc/html/rfc9483#section-4.1.5),
-responses to MAC-based requests at Downstream are always reprotected using the 
-same credentials.
+When responding to request messages that include successfully verified MAC-based protection, the corresponding response messages are protected using the same MAC-based algorithm, credentials, and parameters — regardless of the configuration related to reprotection or output credentials.
+
 Yet on error validating the protection of the request message,
 the configured outgoing credentials are used for the error response message.
 


### PR DESCRIPTION
* `README.md`: move Configuration section to make it more visible and slightly extend it
* `doc/config/README.md`: document the partly surprising protection of responses to requests with MAC-based protection

This came up while handling https://github.com/siemens/gencmpclient/pull/66.