### PR TITLE
Hold RA alive if downstream is an offline interface

### DIFF
--- a/src/main/java/com/siemens/pki/lightweightcmpra/downstream/offline/CmpOfflineFileServer.java
+++ b/src/main/java/com/siemens/pki/lightweightcmpra/downstream/offline/CmpOfflineFileServer.java
@@ -70,7 +70,7 @@ public class CmpOfflineFileServer implements DownstreamInterface {
             throw new IOException(config.getOutputDirectory() + " is not a writable directory");
         }
         final long pollInterval = config.getInputDirectoryPollcycle() * 1000L;
-        pollTimer = new Timer(true);
+        pollTimer = new Timer(false);
         final TimerTask task = new TimerTask() {
 
             @Override


### PR DESCRIPTION
If the RA has only one offline interface polling a directory the RA could terminate due to missing active non-daemon thread 